### PR TITLE
VS Code Server Download URL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
         - attach_workspace: { at: "." }
         - *remote_worker
         - run:
-            name: "Test with Alpine (GLibC edition)"
+            name: "Test VS Code Server with Alpine (GLibC edition)"
             command: |
               cd test/alpine
               DH_IMG=test-alpine-glibc
@@ -84,10 +84,24 @@ jobs:
         - attach_workspace: { at: "." }
         - *remote_worker
         - run:
-            name: "Build Alpine glibc against NodeJS"
+            name: "Test VS Code Server with Debian"
             command: |
               cd test/debian
               DH_IMG=test-debian
+              docker build --rm -t "${DH_IMG}" -f ./Dockerfile ../..
+              docker run --rm --entrypoint /home/app/code-server "${DH_IMG}" --version
+              docker rmi "${DH_IMG}"
+
+    test-alpine-musl:
+      executor: base
+      steps:
+        - attach_workspace: { at: "." }
+        - *remote_worker
+        - run:
+            name: "Test VS Code Server with Alpine musl"
+            command: |
+              cd test/alpine-musl
+              DH_IMG=test-alpine-musl
               docker build --rm -t "${DH_IMG}" -f ./Dockerfile ../..
               docker run --rm --entrypoint /home/app/code-server "${DH_IMG}" --version
               docker rmi "${DH_IMG}"
@@ -104,6 +118,9 @@ workflows:
           context: << pipeline.parameters.ctx_auto_release >>
           requires: [ fetch-code ]
       - test-debian:
+          context: << pipeline.parameters.ctx_auto_release >>
+          requires: [ fetch-code ]
+      - test-alpine-musl:
           context: << pipeline.parameters.ctx_auto_release >>
           requires: [ fetch-code ]
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ remote_worker: &remote_worker
     docker_layer_caching: true
 
 orbs:
-  vr: kohirens/version-release@4.0.1
+  vr: kohirens/version-release@4.0.2
 
 parameters:
   alpine_version_file:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing Guidelines
+
+This repository automatically releases when an approved PR is merged. So please
+adhere to these rules for a smooth fast PR approval.
+
+**Rules**S
+
+* follow the [Commit Message Format] described here. These commits will appear
+  in the changelog and MUST be comprehensible by humans. 
+* provide test where possible to ensure this continue to work.
+* rebase your branch with latest `main` trunk as often as needed.
+
+### Commit Message Format
+
+Each commit message consists of a **header**, a **body** and a **footer**. The
+header has a special format that includes a **type**, a **scope** and a
+**subject**:
+
+```
+<type>(<scope>): <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+The **header** is mandatory and the **scope** of the header is optional.
+
+Example — `fix: Error When Downloading VS Code Server`
+
+Any line of the commit message cannot be longer 100 characters. This allows the
+message to be easier to read on GitHub as well as in various git tools.
+
+#### Type
+
+Must be one of the following:
+
+* **feat**: A new feature.
+* **fix**: A bug fix.
+* **docs**: Documentation only changes.
+* **style**: Changes that do not affect the meaning of the code (white-space,
+  formatting, missing semi-colons, etc).
+* **refactor**: A code change that neither fixes a bug nor adds a feature.
+* **perf**: A code change that improves performance.
+* **test**: Adding missing tests.
+* **chore**: Changes to the build process or auxiliary tools and libraries such
+  as documentation generation.
+
+#### Scope
+
+The scope is optional and could be anything specifying place of the commit
+change. For example `win32`, `mac`, `linux`, etc...
+
+#### Subject
+
+The subject contains succinct description of the change:
+
+* use the past tense: `changed` or `changes` not `change` since the commit
+  should accomplish what is described,
+* Capitalize letters as you would in a header,
+* no punctuation at the end.
+
+#### Body
+
+Briefly describe what the commit accomplishes, it should be done, so you past
+tense, "changed" not "changes" not "change" as if your going to do it.
+
+#### Footer
+
+The footer should contain any information about **Breaking Changes** and is
+also the place to reference GitHub issues that this commit **Closes**.
+
+
+**Breaking Changes** should start with the word `BREAKING CHANGE:` with a
+space or two newlines. The rest of the commit message is then used for this.
+
+This document is based on [Conventional Commits].
+
+[Conventional Commits]: https://www.conventionalcommits.org/en/v1.0.0/
+[Commit Message Format]: #commit-message-format

--- a/download-vs-code-server.sh
+++ b/download-vs-code-server.sh
@@ -87,7 +87,8 @@ if [ -n "${commit_sha}" ]; then
     mkdir -vp ~/.vscode-server/extensions
     # found this in the VSCode remote extension output when connecting to an existing container
     mkdir -vp ~/.vscode-server/extensionsCache
-
+    # This should handle installs for https://vscode.dev/
+    mkdir -vp ~/.vscode/cli/servers/Stable-"${commit_sha}"
     echo "done"
 
     # Extract the tarball to the right location.
@@ -96,8 +97,9 @@ if [ -n "${commit_sha}" ]; then
     echo "done"
 
     # Add symlinks
-    printf "%s" "setup symlinks..."
-    cd ~/.vscode-server/bin && ln -s "${commit_sha}" default_version
+    echo "%s" "setup symlinks"
+    ln -s ~/.vscode-server/bin/"${commit_sha}" ~/.vscode-server/bin/default_version
+    ln -s ~/.vscode-server/bin/"${commit_sha}" ~/.vscode/cli/servers/Stable-"${commit_sha}"/server
     echo "done"
 
     # Used for testing script

--- a/download-vs-code-server.sh
+++ b/download-vs-code-server.sh
@@ -62,30 +62,21 @@ fi
 commit_sha=$(get_latest_release "${PLATFORM}" "${ARCH}")
 
 if [ -n "${commit_sha}" ]; then
-    echo "will attempt to download and pre-configure VS Code Server version '${commit_sha}'"
+    echo "attempting to download and pre-install VS Code Server version '${commit_sha}'"
 
-    # Downloads VS Code with the server built in, not sure how to use that yet or if it possible since VS code client
-    # or the remote extension seems to verify specifics files, like "node"
-    prefix="server-${PLATFORM}"
-    # TODO: Find the correct download location for Alpine, this is just the code cli, which does have the sever built in,
-    # but the tar does not contain any other files that are required for a proper install.
-    # There is a clue when the remote extension installs the server, but it does not reveal the URL where it downloads
-    # it from. Instead it seems to copy it to the container then used the `dd` command to transfer it to the container,
-    # strange indeed.
-    # I don't understand why Alpine is still considered experimental other that the fact that some extensions require
-    # glibc, but the same would be the case for extensions that require python or something else.
-    # Keeping this for now as it was requested. But we need the correct URL. But it does not seem to work as far as
-    # I've tested.
-    if [ "${PLATFORM}" = "alpine" ]; then
-        echo "NOTICE! Alpine is experimental"
-        prefix="cli-${PLATFORM}"
-    fi
+    archive="vscode-server-${PLATFORM}-${ARCH}.tar.gz"
 
-    archive="vscode-${prefix}-${ARCH}.tar.gz"
     printf "%s" "downloading ${archive}..."
     # Download VS Code Server tarball to tmp directory.
-    curl -s --fail -L "https://update.code.visualstudio.com/commit:${commit_sha}/${prefix}-${ARCH}/stable" -o "/tmp/${archive}"
-#    curl -s --fail -L "https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-linux-x64/stable" -o "/tmp/${archive}"
+    curl -s --fail -L "https://update.code.visualstudio.com/commit:${commit_sha}/server-${PLATFORM}-${ARCH}/stable" -o "/tmp/${archive}"
+    # Examples:
+    # curl -s --fail -L "https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-linux-x64/stable" -o "/tmp/${archive}"
+    # curl -s --fail -L "https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-darwin-arm64/stable" -o "/tmp/${archive}"D
+    # curl -s --fail -L "https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-linux-alpine/stable" -o "/tmp/${archive}"D
+    # TODO: Provide a script for downloading on Windows
+    # curl -s --fail -L "https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-win32-x64/stable" -o "/tmp/${archive}"D
+    # With this URL you can get Insider editions 't need the latest commit hash, as it always gets latest
+    # https://update.code.visualstudio.com/commit:${commit_sha}/server-${PLATFORM}-${ARCH}/insider
     echo "done"
 
     echo "setup directories:"

--- a/test/alpine-musl/Dockerfile
+++ b/test/alpine-musl/Dockerfile
@@ -3,9 +3,8 @@ ARG USER_UID='1000'
 ARG USER_GID='1000'
 ARG USER_GROUP='app_users'
 ARG REPO='githunb.com/b01/dl-vscode-server'
-ARG WD="/home/${USER_NAME}/src/${REPO}/test/alpine"
+ARG WD="/home/${USER_NAME}/src/${REPO}/test/alpine-musl"
 
-# VS Code, unfortunately, relies on GNU Lib C. So see if we can use Kohirens Alpine GNU LibC image.
 FROM alpine:3.19
 
 ARG USER_NAME
@@ -15,6 +14,10 @@ ARG USER_GROUP
 ARG REPO
 ARG WD
 
+WORKDIR /tmp
+
+# VS Code Server requirements, for details see:
+# https://code.visualstudio.com/docs/remote/linux
 RUN apk --no-progress --purge --no-cache upgrade \
  && apk --no-progress --purge --no-cache add --upgrade \
     bash \
@@ -26,7 +29,7 @@ RUN apk --no-progress --purge --no-cache upgrade \
     python3 \
 && apk --no-progress --purge --no-cache upgrade \
  && rm -vrf /var/cache/apk/*
-#
+
 ## Add a non-root group and user to runas
 #RUN addgroup --system --gid ${USER_GID} ${USER_GROUP} \
 # && adduser --system \
@@ -45,9 +48,11 @@ HEALTHCHECK --interval=5m --timeout=3s \
 ENTRYPOINT [ "start.sh" ]
 
 COPY --chmod=${USER_NAME}:${USER_NAME} download-vs-code-server.sh /tmp
+COPY --chmod=${USER_NAME}:${USER_NAME} setup-server-via-vs-code-cli.sh /tmp
 
 # Install VS Code Server
-RUN /tmp/download-vs-code-server.sh "alpine" "x64" "yes"
-#
+RUN /tmp/download-vs-code-server.sh "linux" "alpine" "yes"
+RUN #/tmp/setup-server-via-vs-code-cli.sh "linux" "alpine" "yes"
+
 #WORKDIR ${WD}
 #SHELL [ "/bin/bash", "-c" ]

--- a/test/alpine-musl/Dockerfile
+++ b/test/alpine-musl/Dockerfile
@@ -31,15 +31,15 @@ RUN apk --no-progress --purge --no-cache upgrade \
  && rm -vrf /var/cache/apk/*
 
 ## Add a non-root group and user to runas
-#RUN addgroup --system --gid ${USER_GID} ${USER_GROUP} \
-# && adduser --system \
-#    --disabled-password \
-#    --ingroup ${USER_GROUP} \
-#    --uid ${USER_UID} \
-#    ${USER_NAME}
-#
-#USER ${USER_NAME}
-#
+RUN addgroup --system --gid ${USER_GID} ${USER_GROUP} \
+ && adduser --system \
+    --disabled-password \
+    --ingroup ${USER_GROUP} \
+    --uid ${USER_UID} \
+    ${USER_NAME}
+
+USER ${USER_NAME}
+
 COPY --chmod=${USER_NAME}:${USER_NAME} test/alpine/start.sh /usr/local/bin
 
 HEALTHCHECK --interval=5m --timeout=3s \
@@ -52,7 +52,6 @@ COPY --chmod=${USER_NAME}:${USER_NAME} setup-server-via-vs-code-cli.sh /tmp
 
 # Install VS Code Server
 RUN /tmp/download-vs-code-server.sh "linux" "alpine" "yes"
-RUN #/tmp/setup-server-via-vs-code-cli.sh "linux" "alpine" "yes"
+RUN /tmp/setup-server-via-vs-code-cli.sh "alpine" "x64" "yes"
 
-#WORKDIR ${WD}
-#SHELL [ "/bin/bash", "-c" ]
+WORKDIR ${WD}

--- a/test/alpine-musl/Dockerfile
+++ b/test/alpine-musl/Dockerfile
@@ -40,18 +40,16 @@ RUN addgroup --system --gid ${USER_GID} ${USER_GROUP} \
 
 USER ${USER_NAME}
 
-COPY --chmod=${USER_NAME}:${USER_NAME} test/alpine/start.sh /usr/local/bin
+COPY --chown=${USER_NAME}:${USER_NAME} test/alpine/start.sh /usr/local/bin
 
 HEALTHCHECK --interval=5m --timeout=3s \
   CMD echo "healthy" || exit 1
 
 ENTRYPOINT [ "start.sh" ]
 
-COPY --chmod=${USER_NAME}:${USER_NAME} download-vs-code-server.sh /tmp
-COPY --chmod=${USER_NAME}:${USER_NAME} setup-server-via-vs-code-cli.sh /tmp
+COPY --chown=${USER_NAME}:${USER_NAME} --chmod=777 download-vs-code-server.sh /tmp
 
 # Install VS Code Server
 RUN /tmp/download-vs-code-server.sh "linux" "alpine" "yes"
-RUN /tmp/setup-server-via-vs-code-cli.sh "alpine" "x64" "yes"
 
 WORKDIR ${WD}

--- a/test/alpine/Dockerfile
+++ b/test/alpine/Dockerfile
@@ -5,7 +5,9 @@ ARG USER_GROUP='app_users'
 ARG REPO='githunb.com/b01/dl-vscode-server'
 ARG WD="/home/${USER_NAME}/src/${REPO}/test/alpine"
 
-# VS Code, unfortunately, relies on GNU Lib C. So see if we can use Kohirens Alpine GNU LibC image.
+# VS Code, unfortunately, relies on GNU Lib C as may some extensions. Good news,
+# we can use Kohirens Alpine GNU LibC image as base, it has GNY Lib C built for
+# Alpine (in an Alpine container) and it works!
 FROM kohirens/alpine-glibc:3.19-2.39
 
 ARG USER_NAME
@@ -15,6 +17,10 @@ ARG USER_GROUP
 ARG REPO
 ARG WD
 
+WORKDIR /tmp
+
+# VS Code Server requirements, for details see:
+# https://code.visualstudio.com/docs/remote/linux
 RUN apk --no-progress --purge --no-cache upgrade \
  && apk --no-progress --purge --no-cache add --upgrade \
     bash \

--- a/test/debian/Dockerfile
+++ b/test/debian/Dockerfile
@@ -15,6 +15,8 @@ ARG USER_GROUP
 ARG REPO
 ARG WD
 
+WORKDIR /tmp
+
 # VS Code Server requirements: openssh, musl, libgcc, libstdc++
 # For details see: https://code.visualstudio.com/docs/remote/linux
 RUN apt-get -qq update -qq && apt-get -qq install -qq \


### PR DESCRIPTION
## Added

* VS Code Symlink - Added a symbolic linkfor `~/.vscode/cli/servers/Stable-"${commit_sha}"/server`.

## Fixed

* VS Code Server Download URL - After finding the correct VS Code Server download URL for Alpine, the code has been change to pull any server available using the this format. Including Alpine with no GNU LibC installed, Windows, Mac, and Linux.