### PR TITLE
Updates 2024 05 16 01

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ remote_worker: &remote_worker
     docker_layer_caching: true
 
 orbs:
-  vr: kohirens/version-release@4.0.2
+  vr: kohirens/version-release@4.0.3
 
 parameters:
   alpine_version_file:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,7 @@ jobs:
               DH_IMG=test-alpine-glibc
               docker build --rm -t "${DH_IMG}" -f ./Dockerfile ../..
               docker run --rm --entrypoint /home/app/code-server "${DH_IMG}" --version
+              docker run --rm --entrypoint /home/app/code "${DH_IMG}" --version
               docker rmi "${DH_IMG}"
 
     test-debian:
@@ -90,6 +91,7 @@ jobs:
               DH_IMG=test-debian
               docker build --rm -t "${DH_IMG}" -f ./Dockerfile ../..
               docker run --rm --entrypoint /home/app/code-server "${DH_IMG}" --version
+              docker run --rm --entrypoint /home/app/code "${DH_IMG}" --version
               docker rmi "${DH_IMG}"
 
     test-alpine-musl:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,19 @@
+# Copyright 2024 Khalifah K. Shabazz
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the “Software”),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # DL VS Code Server
 
-This script downloads a tar of VS Code Server, then extracts it to a location
-expected by VS Code clients. The intention of this script is to pre-install
-the server during image build. This helps ensure, in certain scenarios,
-that the server is there when internet is not; while still allowing your VS
-Code client to connect to it.
+This script downloads a tar of VS Code Server/CLI, then extracts it to a
+location expected by tunnels made by VS Code clients.
 
-To get the latest version of VS COde server pre-installed, then re-run the
+The intention of this script is to pre-install the VS Code binary during
+container image build. This helps ensure, in certain scenarios, that the binary
+is there when internet is not; while still allowing your VS Code client to
+tunnel to the container.
+
+When the VS Code binary is out-of-date, to get the latest version, re-run the
 script.
 
 ## Background
@@ -23,26 +25,52 @@ script at [b01/download-vs-code-server.sh]
 
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/b01/dl-vscode-server/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/b01/dl-vscode-server/tree/main)
 
-## How To Use
+## How To Install
 
-You only need to download the script `download-vs-code-server.sh` and run it.
-
-`download-vs-code-server.sh <PLATFORM> <ARCH>`
-
-Example:
-
+### Shell
 ```shell
 curl -L https://raw.githubusercontent.com/b01/dl-vscode-server/main/download-vs-code-server.sh | bash -s -- "linux"
 ```
 
-### Arguments
+### Docker
 
-**PLATFORM** - Currently `linux`, `alpine`, and any others Microsoft supports.
+```dockerfile
+ADD --chmod=777 \
+    https://raw.githubusercontent.com/b01/dl-vscode-server/updates-2024-05-16-01/download-vs-code.sh \
+    .
 
-**ARCH** - Optional, will default to `uname -m`, which will map to a value
-that Microsoft expects, so for, aarch64 => arm64, x86_64 => x64, and so on.
-`armv7l` will map to armhf. It best to specify the arch if you know it.
-If you supply a value, that will be used without being mapped.
+# Install VS Code Server and Requirements
+RUN ./download-vs-code.sh "linux" "x64" --alpine
+```
+
+## How To Use
+
+`download-vs-code.sh [options] <PLATFORM> [<ARCH>]`
+
+### Example:
+
+download-vs-code.sh \"linux\" \"x64\" --alpine
+
+### Options
+
+`--insider`
+Switches to the pre-released version of the binary chosen (server or
+CLI).
+
+`--dump-sha`
+Will print the latest commit sha for VS Code (server and CLI are current
+synced and always the same)
+
+`--cli`
+Switches the binary download VS Code CLI.
+
+`--alpine`
+Only works when downloading VS Code Server, it will force PLATFORM=linux and
+ARCH=alpine, as the developers deviated from the standard format used for all
+others.
+
+`-h, --help`
+Print this usage info
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # DL VS Code Server
 
 This script downloads a tar of VS Code Server, then extracts it to a location
-expected by VS Code clients. The intention of this script is to download and
-setup of the server during image build. This helps to ensure in certain
-scenarios that the server is there when internet is not, while still allowing
-your VS code client to connect to it.
+expected by VS Code clients. The intention of this script is to pre-install
+the server during image build. This helps ensure, in certain scenarios,
+that the server is there when internet is not; while still allowing your VS
+Code client to connect to it.
 
-To get the latest version of VS COde server, just rebuild the image.
+To get the latest version of VS COde server pre-installed, then re-run the
+script.
 
 ## Background
 
@@ -36,11 +37,12 @@ curl -L https://raw.githubusercontent.com/b01/dl-vscode-server/main/download-vs-
 
 ### Arguments
 
-**PLATFORM** - Currently only `linux` or `alpine` are supported.
+**PLATFORM** - Currently `linux`, `alpine`, and any others Microsoft supports.
 
 **ARCH** - Optional, will default to `uname -m`, which will map to a value
-that Microsoft expects, so for, aarch64 => arm64, x86_64 => x64, and
-armv7l => armhf. If you supply a value, that will be used without being mapped.
+that Microsoft expects, so for, aarch64 => arm64, x86_64 => x64, and so on.
+`armv7l` will map to armhf. It best to specify the arch if you know it.
+If you supply a value, that will be used without being mapped.
 
 ---
 

--- a/docs/how-to-test.md
+++ b/docs/how-to-test.md
@@ -1,0 +1,35 @@
+# Testing
+
+The VS Code Server has a lot of location where it needs to reside for the many
+different type of DevContainer setups. These instructions should provide how
+to verify the script still works in those scenarios. Each heading below
+represents a different scenario.
+## Pre-requisites
+
+1. Start Docker Desktop (or equivalent) if it has not been started already.
+2. Clone this project locally and open it in VSCode.
+3. In VS Code, open a terminal/shell (you should be in the project directory).
+
+## Local VSCode To Local Container
+
+## VSCode.dev
+
+Start a test container, should not matter which one (we'll use Alpine for
+this example):
+
+1. `cd test/alpine-musl`
+2. Run `docker compose up`
+3. Login to the container: 
+4. Create a secure tunnel with the tunnel command:
+   ```shell
+    ~/code tunnel --accept-server-license-terms
+   ```
+5. Perform all the action netting you a URL to vscode.dev, click the URL to
+   open it in your browser.
+6. Review the output in the terminal to verify no vscode server installation
+   occurs.
+
+## Web VSCode to Remote Container
+
+Untested.
+

--- a/docs/how-to-test.md
+++ b/docs/how-to-test.md
@@ -4,6 +4,31 @@ The VS Code Server has a lot of location where it needs to reside for the many
 different type of DevContainer setups. These instructions should provide how
 to verify the script still works in those scenarios. Each heading below
 represents a different scenario.
+
+## VS Code Download URL Format
+
+These URLS helped derived format to remove guessing where to download.
+
+### CLI URLs
+```shell
+# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/cli-linux-x64/stable
+# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/cli-alpine-x64/stable
+# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/cli-darwin-x64/stable
+# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/cli-darwin-arm64/stable
+# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/cli-win32-x64/stable
+# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/cli-win32-arm64/stable
+```
+
+### Server
+
+```shell
+# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-linux-x64/stable
+# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-darwin-x64/stable
+# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-darwin-arm64/stable
+# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-linux-alpine/stable
+# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-win32-x64/stable
+```
+
 ## Pre-requisites
 
 1. Start Docker Desktop (or equivalent) if it has not been started already.
@@ -32,4 +57,3 @@ this example):
 ## Web VSCode to Remote Container
 
 Untested.
-

--- a/download-vs-code-server.sh
+++ b/download-vs-code-server.sh
@@ -100,7 +100,7 @@ if [ -n "${commit_sha}" ]; then
     echo "done"
 
     # Add symlinks
-    echo "%s" "setup symlinks"
+    printf "%s" "setup symlinks..."
     ln -s ~/.vscode-server/bin/"${commit_sha}" ~/.vscode-server/bin/default_version
     ln -s ~/.vscode-server/bin/"${commit_sha}" ~/.vscode/cli/servers/Stable-"${commit_sha}"/server
     echo "done"

--- a/download-vs-code-server.sh
+++ b/download-vs-code-server.sh
@@ -68,20 +68,23 @@ if [ -n "${commit_sha}" ]; then
 
     printf "%s" "downloading ${archive}..."
     # Download VS Code Server tarball to tmp directory.
-    curl -s --fail -L "https://update.code.visualstudio.com/commit:${commit_sha}/server-${PLATFORM}-${ARCH}/stable" -o "/tmp/${archive}"
-    # Examples:
-    # curl -s --fail -L "https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-linux-x64/stable" -o "/tmp/${archive}"
-    # curl -s --fail -L "https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-darwin-arm64/stable" -o "/tmp/${archive}"D
-    # curl -s --fail -L "https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-linux-alpine/stable" -o "/tmp/${archive}"D
-    # TODO: Provide a script for downloading on Windows
-    # curl -s --fail -L "https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-win32-x64/stable" -o "/tmp/${archive}"D
-    # With this URL you can get Insider editions 't need the latest commit hash, as it always gets latest
+    curl -s --fail -L "https://update.code.visualstudio.com/commit:${commit_sha}/server-${PLATFORM}-${ARCH}/${BUILD}" -o "/tmp/${archive}"
+    # Working URLs that helped derived format:
+    # https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-linux-x64/stable
+    # https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-darwin-x64/stable
+    # https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-darwin-arm64/stable
+    # https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-linux-alpine/stable
+    # https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-win32-x64/stable
+
+    # NOTE: With this URL you can get Insider editions 't need the latest commit hash, as it always gets latest
     # https://update.code.visualstudio.com/commit:${commit_sha}/server-${PLATFORM}-${ARCH}/insider
     echo "done"
 
     echo "setup directories:"
-    # Make the parent directory where the server should live.
-    # NOTE: VS Code will runas the logged in user, so ensure they have read/write to the following directories
+    # Make the directories where the VS Code will search. There may be others not
+    # listed here.
+    # NOTE: VS Code will runas the logged in user, so ensure they have
+    #       read/write to the following directories
     mkdir -vp ~/.vscode-server/bin/"${commit_sha}"
     # VSCode Requirements for pre-installing extensions
     mkdir -vp ~/.vscode-server/extensions

--- a/download-vs-code.sh
+++ b/download-vs-code.sh
@@ -88,7 +88,7 @@ install_server() {
     echo "done"
 
     # Add symlinks
-    echo "%s" "setup symlinks"
+    printf "%s" "setup symlinks..."
     ln -s ~/.vscode-server/bin/"${commit_sha}" ~/.vscode-server/bin/default_version
     ln -s ~/.vscode-server/bin/"${commit_sha}" ~/.vscode/cli/servers/Stable-"${commit_sha}"/server
     ln -s ~/.vscode-server/bin/"${commit_sha}" ~/.vscode-server/cli/servers/Stable-${commit_sha}/server
@@ -200,7 +200,7 @@ archive="vscode-${options}.tar.gz"
 # https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-win32-x64/stable
 # Download VS Code tarball to the current directory.
 url="https://update.code.visualstudio.com/commit:${commit_sha}/${options}/${BUILD}"
-printf "%s" "downloading ${url}...${archive}"
+printf "%s" "downloading ${url} to ${archive} "
 curl -s --fail -L "${url}" -o "/tmp/${archive}"
 echo "done"
 

--- a/download-vs-code.sh
+++ b/download-vs-code.sh
@@ -80,6 +80,7 @@ install_server() {
     mkdir -vp ~/.vscode-server/extensionsCache
     # This should handle installs for https://vscode.dev/
     mkdir -vp ~/.vscode/cli/servers/Stable-"${commit_sha}"
+    mkdir -vp ~/.vscode-server/cli/servers/Stable-"${commit_sha}"
     echo "done"
 
     # Extract the tarball to the right location.
@@ -91,7 +92,7 @@ install_server() {
     printf "%s" "setup symlinks..."
     ln -s ~/.vscode-server/bin/"${commit_sha}" ~/.vscode-server/bin/default_version
     ln -s ~/.vscode-server/bin/"${commit_sha}" ~/.vscode/cli/servers/Stable-"${commit_sha}"/server
-    ln -s ~/.vscode-server/bin/"${commit_sha}" ~/.vscode-server/cli/servers/Stable-${commit_sha}/server
+    ln -s ~/.vscode-server/bin/"${commit_sha}" ~/.vscode-server/cli/servers/Stable-"${commit_sha}"/server
     ln -s ~/.vscode-server/bin/"${commit_sha}"/bin/code-server ~/code-server
     echo "done"
 }

--- a/download-vs-code.sh
+++ b/download-vs-code.sh
@@ -100,7 +100,7 @@ PLATFORM=""
 ARCH=""
 BUILD="stable"
 BIN_TYPE="server"
-RETURN_VERSION=""
+DUMP_COMMIT_SHA=""
 IS_ALPINE=0
 
 while [ ${#} -gt 0 ]; do
@@ -110,8 +110,8 @@ while [ ${#} -gt 0 ]; do
         --insider)
             BUILD="insider"
             ;;
-        --dump-version)
-            RETURN_VERSION="yes"
+        --dump-sha)
+            DUMP_COMMIT_SHA="yes"
             ;;
         --cli)
             BIN_TYPE="cli"
@@ -176,9 +176,9 @@ if [ -z "${commit_sha}" ]; then
     exit 1
 fi
 
-# Used for testing script
-if [ "${RETURN_VERSION}" = "yes" ]; then
-    echo "${commit_sha}" > "${HOME}"/vs-code-"${BIN_TYPE}"-version.txt
+if [ "${DUMP_COMMIT_SHA}" = "yes" ]; then
+    echo "${commit_sha}"
+    exit 0
 fi
 
 echo "attempting to download and pre-install VS Code ${BIN_TYPE} version '${commit_sha}'"

--- a/download-vs-code.sh
+++ b/download-vs-code.sh
@@ -91,7 +91,8 @@ install_server() {
     echo "%s" "setup symlinks"
     ln -s ~/.vscode-server/bin/"${commit_sha}" ~/.vscode-server/bin/default_version
     ln -s ~/.vscode-server/bin/"${commit_sha}" ~/.vscode/cli/servers/Stable-"${commit_sha}"/server
-    ln -s "${HOME}"/.vscode-server/bin/"${commit_sha}"/bin/code-server "${HOME}"/code-server
+    ln -s ~/.vscode-server/bin/"${commit_sha}" ~/.vscode-server/cli/servers/Stable-${commit_sha}/server
+    ln -s ~/.vscode-server/bin/"${commit_sha}"/bin/code-server ~/code-server
     echo "done"
 }
 

--- a/download-vs-code.sh
+++ b/download-vs-code.sh
@@ -21,7 +21,36 @@
 # IN THE SOFTWARE.
 
 set -e
+usage="
+This script downloads a tar of VS Code Server/CLI, then extracts it to a
+location expected by tunnels made by VS Code clients.
 
+download-vs-code.sh [options] <PLATFORM> [<ARCH>]
+
+Example:
+  download-vs-code.sh \"linux\" \"x64\" --alpine
+
+Options
+
+--insider
+    Switches to the pre-released version of the binary chosen (server or
+    CLI).
+
+--dump-sha
+    Will print the latest commit sha for VS Code (server and CLI are current
+    synced and always the same).
+
+--cli
+    Switches the binary download VS Code CLI.
+
+--alpine
+    Only works when downloading VS Code Server, it will force PLATFORM=linux and
+    ARCH=alpine, as the developers deviated from the standard format used for
+    all others.
+
+-h, --help
+    Print this usage info.
+"
 # Get the latest VS Code commit sha.
 get_latest_release() {
     platform=${1}
@@ -120,6 +149,10 @@ while [ ${#} -gt 0 ]; do
         --alpine)
             IS_ALPINE=1
             ;;
+        -h|--help)
+            echo "${usage}"
+            exit 0
+            ;;
         -*|--*)
             echo "Unknown option ${op}"
             exit 1
@@ -170,6 +203,7 @@ if [ "${BIN_TYPE}" = "server" -a ${IS_ALPINE} -eq 1 ]; then
     ARCH="alpine" # Alpine is NOT an Arch but a flavor of Linux, oh well.
 fi
 
+# We hard-code this because all but a few options returns a 404.
 commit_sha=$(get_latest_release "win32" "x64" "${BUILD}")
 
 if [ -z "${commit_sha}" ]; then
@@ -187,18 +221,6 @@ echo "attempting to download and pre-install VS Code ${BIN_TYPE} version '${comm
 options="${BIN_TYPE}-${PLATFORM}-${ARCH}"
 archive="vscode-${options}.tar.gz"
 
-# URLs that helped derived format:
-# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/cli-linux-x64/stable
-# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/cli-alpine-x64/stable
-# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/cli-darwin-x64/stable
-# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/cli-darwin-arm64/stable
-# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/cli-win32-x64/stable
-# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/cli-win32-arm64/stable
-# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-linux-x64/stable
-# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-darwin-x64/stable
-# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-darwin-arm64/stable
-# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-linux-alpine/stable
-# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-win32-x64/stable
 # Download VS Code tarball to the current directory.
 url="https://update.code.visualstudio.com/commit:${commit_sha}/${options}/${BUILD}"
 printf "%s" "downloading ${url} to ${archive} "

--- a/download-vs-code.sh
+++ b/download-vs-code.sh
@@ -1,0 +1,213 @@
+#!/bin/sh
+
+# Copyright 2024 Khalifah K. Shabazz
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the “Software”),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+set -e
+
+# Get the latest VS Code commit sha.
+get_latest_release() {
+    platform=${1}
+    arch=${2}
+    bin_type="${3}"
+
+    # Grab the first commit SHA since as this script assumes it will be the
+    # latest.
+    commit_id=$(curl --silent "https://update.code.visualstudio.com/api/commits/${bin_type}/${platform}-${arch}" | sed s'/^\["\([^"]*\).*$/\1/')
+
+    # These work:
+    # https://update.code.visualstudio.com/api/commits/stable/win32-x64
+    # https://update.code.visualstudio.com/api/commits/stable/linux-x64
+    # https://update.code.visualstudio.com/api/commits/insider/linux-x64
+
+    # these do not work:
+    # https://update.code.visualstudio.com/api/commits/stable/darwin-x64
+    # https://update.code.visualstudio.com/api/commits/stable/linux-alpine
+    printf "%s" "${commit_id}"
+}
+
+# You can test the code binary is installed in the correct location by
+# making a tunnel to vscode.dev with:
+# ~/.vscode-server/code tunnel --accept-server-license-terms
+install_cli() {
+    echo "setup directories:"
+    # Make the directories where the VS Code will search. There may be others not
+    # listed here.
+    # NOTE: VS Code will runas the logged in user, so ensure they have
+    #       read/write to the following directories
+    mkdir -vp ~/.vscode-server
+    echo "done"
+
+    # Extract the tarball to the right location.
+    printf "%s" "extracting ${archive}..."
+    tar -xz -C ~/.vscode-server --no-same-owner -f "/tmp/${archive}"
+    echo "done"
+
+    # Add symlinks
+    printf "%s" "setup symlinks..."
+    ln -s ~/.vscode-server/code ~/.vscode-server/code-"${commit_sha}"
+    ln -s "${HOME}"/.vscode-server/code ~/code
+    echo "done"
+}
+
+install_server() {
+    echo "setup directories:"
+    # Make the directories where the VS Code will search. There may be others not
+    # listed here.
+    # NOTE: VS Code will runas the logged in user, so ensure they have
+    #       read/write to the following directories
+    mkdir -vp ~/.vscode-server/bin/"${commit_sha}"
+    # VSCode Requirements for pre-installing extensions
+    mkdir -vp ~/.vscode-server/extensions
+    # found this in the VSCode remote extension output when connecting to an existing container
+    mkdir -vp ~/.vscode-server/extensionsCache
+    # This should handle installs for https://vscode.dev/
+    mkdir -vp ~/.vscode/cli/servers/Stable-"${commit_sha}"
+    echo "done"
+
+    # Extract the tarball to the right location.
+    printf "%s" "extracting ${archive}..."
+    tar -xz -C ~/.vscode-server/bin/"${commit_sha}" --strip-components=1 --no-same-owner -f "/tmp/${archive}"
+    echo "done"
+
+    # Add symlinks
+    echo "%s" "setup symlinks"
+    ln -s ~/.vscode-server/bin/"${commit_sha}" ~/.vscode-server/bin/default_version
+    ln -s ~/.vscode-server/bin/"${commit_sha}" ~/.vscode/cli/servers/Stable-"${commit_sha}"/server
+    ln -s "${HOME}"/.vscode-server/bin/"${commit_sha}"/bin/code-server "${HOME}"/code-server
+    echo "done"
+}
+
+PLATFORM=""
+ARCH=""
+BUILD="stable"
+BIN_TYPE="server"
+RETURN_VERSION=""
+IS_ALPINE=0
+
+while [ ${#} -gt 0 ]; do
+    op="${1}"
+    shift
+    case ${op} in
+        --insider)
+            BUILD="insider"
+            ;;
+        --dump-version)
+            RETURN_VERSION="yes"
+            ;;
+        --cli)
+            BIN_TYPE="cli"
+            ;;
+        --alpine)
+            IS_ALPINE=1
+            ;;
+        -*|--*)
+            echo "Unknown option ${op}"
+            exit 1
+            ;;
+        *)
+            if [ -n "${op}" ]; then
+                case ${op} in
+                    # We can't put Alpine here because the server download required PLATFORM=linux and ARCH=alpine.
+                    alpine|darwin|linux|win32)
+                      PLATFORM="${op}"
+                      ;;
+                    arm64|armhf|x64)
+                      ARCH="${op}"
+                      ;;
+                    *)
+                      echo "Unknown option ${op}"
+                      exit 1
+                      ;;
+                esac
+            fi
+            ;;
+    esac
+done
+
+# Platform is required.
+if [ -z "${PLATFORM}" ]; then
+    echo "please specify which platform version of VS Code to install\nacceptable values are win32, linux, darwin, or alpine"
+    exit 1
+fi
+
+# When non specified, then pull from the OS.
+if [ -z "${ARCH}" ]; then
+    U_NAME=$(uname -m)
+
+    if [ "${U_NAME}" = "aarch64" ]; then
+        ARCH="arm64"
+    elif [ "${U_NAME}" = "x86_64" ]; then
+        ARCH="x64"
+    elif [ "${U_NAME}" = "armv7l" ]; then
+        ARCH="armhf"
+    fi
+fi
+
+# Patch things when downloading VS Code Server for Alpine.
+if [ "${BIN_TYPE}" = "server" -a ${IS_ALPINE} -eq 1 ]; then
+    echo "we need to hard set PLATFORM and ARCH for Alpine Musl"
+    PLATFORM="linux"
+    ARCH="alpine" # Alpine is NOT an Arch but a flavor of Linux, oh well.
+fi
+
+commit_sha=$(get_latest_release "win32" "x64" "${BUILD}")
+
+if [ -z "${commit_sha}" ]; then
+    echo "could not get the VS Code latest commit sha, exiting"
+    exit 1
+fi
+
+# Used for testing script
+if [ "${RETURN_VERSION}" = "yes" ]; then
+    echo "${commit_sha}" > "${HOME}"/vs-code-"${BIN_TYPE}"-version.txt
+fi
+
+echo "attempting to download and pre-install VS Code ${BIN_TYPE} version '${commit_sha}'"
+
+options="${BIN_TYPE}-${PLATFORM}-${ARCH}"
+archive="vscode-${options}.tar.gz"
+
+# URLs that helped derived format:
+# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/cli-linux-x64/stable
+# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/cli-alpine-x64/stable
+# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/cli-darwin-x64/stable
+# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/cli-darwin-arm64/stable
+# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/cli-win32-x64/stable
+# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/cli-win32-arm64/stable
+# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-linux-x64/stable
+# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-darwin-x64/stable
+# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-darwin-arm64/stable
+# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-linux-alpine/stable
+# https://update.code.visualstudio.com/commit:b58957e67ee1e712cebf466b995adf4c5307b2bd/server-win32-x64/stable
+# Download VS Code tarball to the current directory.
+url="https://update.code.visualstudio.com/commit:${commit_sha}/${options}/${BUILD}"
+printf "%s" "downloading ${url}...${archive}"
+curl -s --fail -L "${url}" -o "/tmp/${archive}"
+echo "done"
+
+# Based on the binary type chosen, perform the installation.
+if [ "${BIN_TYPE}" = "cli" ]; then
+    install_cli
+else
+    install_server
+fi
+
+echo "VS Code server pre-install completed"

--- a/test/alpine-musl/.devcontainer.json
+++ b/test/alpine-musl/.devcontainer.json
@@ -1,8 +1,8 @@
 {
 	"name": "dl-vscode-server-test",
-	"dockerComposeFile": "../compose.yml",
-	"service": "alpine",
-	"workspaceFolder": "/home/app/src/github.com/b01/dl-vscode-server/test/alpine",
+	"dockerComposeFile": "compose.yml",
+	"service": "alpine-musl",
+	"workspaceFolder": "/home/app/src/github.com/b01/dl-vscode-server/test/alpine-musl",
 	// Use this environment variable if you need to bind mount your local source code into a new container.
 	"remoteEnv": {
 		"LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}"
@@ -12,7 +12,7 @@
 	"customizations": {
 		"vscode": {
 			"settings": {
-				"terminal.integrated.shell.linux": "/bin/sh",
+				"terminal.integrated.shell.linux": "/bin/bash",
 			},
 			// Add the IDs of extensions you want installed when the container is created.
 			"extensions": [

--- a/test/alpine-musl/Dockerfile
+++ b/test/alpine-musl/Dockerfile
@@ -43,6 +43,7 @@ RUN addgroup --system --gid ${USER_GID} ${USER_GROUP} \
     --disabled-password \
     --ingroup ${USER_GROUP} \
     --uid ${USER_UID} \
+    --shell /bin/bash \
     ${USER_NAME}
 
 USER ${USER_NAME}

--- a/test/alpine-musl/Dockerfile
+++ b/test/alpine-musl/Dockerfile
@@ -51,7 +51,7 @@ COPY --chown=${USER_NAME}:${USER_NAME} --chmod=777 download-vs-code.sh /tmp
 
 # Install VS Code Server
 # NOTE: To download VS Code server use the --alpine flag to force PLATFORM="linux" and ARCH="alpine", the actual input will be ignored.
-RUN /tmp/download-vs-code.sh "alpine" "x64" --dump-version --alpine
-RUN /tmp/download-vs-code.sh "alpine" "x64" --dump-version --cli
+RUN /tmp/download-vs-code.sh "alpine" "x64" --alpine
+RUN /tmp/download-vs-code.sh "alpine" "x64" --cli
 
 WORKDIR ${WD}

--- a/test/alpine-musl/Dockerfile
+++ b/test/alpine-musl/Dockerfile
@@ -30,6 +30,13 @@ RUN apk --no-progress --purge --no-cache upgrade \
 && apk --no-progress --purge --no-cache upgrade \
  && rm -vrf /var/cache/apk/*
 
+COPY  --chmod=+x test/alpine/start.sh /usr/local/bin
+
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD echo "healthy" || exit 1
+
+ENTRYPOINT [ "start.sh" ]
+
 ## Add a non-root group and user to runas
 RUN addgroup --system --gid ${USER_GID} ${USER_GROUP} \
  && adduser --system \
@@ -40,16 +47,11 @@ RUN addgroup --system --gid ${USER_GID} ${USER_GROUP} \
 
 USER ${USER_NAME}
 
-COPY --chown=${USER_NAME}:${USER_NAME} test/alpine/start.sh /usr/local/bin
-
-HEALTHCHECK --interval=5m --timeout=3s \
-  CMD echo "healthy" || exit 1
-
-ENTRYPOINT [ "start.sh" ]
-
-COPY --chown=${USER_NAME}:${USER_NAME} --chmod=777 download-vs-code-server.sh /tmp
+COPY --chown=${USER_NAME}:${USER_NAME} --chmod=+x download-vs-code.sh /tmp
 
 # Install VS Code Server
-RUN /tmp/download-vs-code-server.sh "linux" "alpine" "yes"
+# NOTE: To download VS Code server use the --alpine flag to force PLATFORM="linux" and ARCH="alpine", the actual input will be ignored.
+RUN /tmp/download-vs-code.sh "alpine" "x64" --dump-version --alpine
+RUN /tmp/download-vs-code.sh "alpine" "x64" --dump-version --cli
 
 WORKDIR ${WD}

--- a/test/alpine-musl/Dockerfile
+++ b/test/alpine-musl/Dockerfile
@@ -47,7 +47,7 @@ RUN addgroup --system --gid ${USER_GID} ${USER_GROUP} \
 
 USER ${USER_NAME}
 
-COPY --chown=${USER_NAME}:${USER_NAME} --chmod=+x download-vs-code.sh /tmp
+COPY --chown=${USER_NAME}:${USER_NAME} --chmod=777 download-vs-code.sh /tmp
 
 # Install VS Code Server
 # NOTE: To download VS Code server use the --alpine flag to force PLATFORM="linux" and ARCH="alpine", the actual input will be ignored.

--- a/test/alpine-musl/Dockerfile
+++ b/test/alpine-musl/Dockerfile
@@ -30,7 +30,7 @@ RUN apk --no-progress --purge --no-cache upgrade \
 && apk --no-progress --purge --no-cache upgrade \
  && rm -vrf /var/cache/apk/*
 
-COPY  --chmod=+x test/alpine/start.sh /usr/local/bin
+COPY  --chmod=+x test/alpine-musl/start.sh /usr/local/bin
 
 HEALTHCHECK --interval=5m --timeout=3s \
   CMD echo "healthy" || exit 1

--- a/test/alpine-musl/README.md
+++ b/test/alpine-musl/README.md
@@ -1,8 +1,10 @@
 # About
 
-This container is for testing out the pre-installed vscode server setup inside an Alpine contiainer.
+This container is for testing out the pre-installed vscode server setup inside
+an Alpine container.
 
-This image uses the Kohirens [Alpine GLIBC] image as a base, so you get a real version of GNU LibC built in an Alpine container for Alpine. So it should not have issues running node for VS Code server. Beside the warning about libc++ not having any version info.
+This image does not have GNU LibC of any kind installed and uses the Musl based
+version of VS Code Server.
 
 ---
 

--- a/test/alpine-musl/start.sh
+++ b/test/alpine-musl/start.sh
@@ -23,9 +23,8 @@ echo "Started"
 
 last_signal=""
 
-# Fork a loop as a child process, which keeps this script running. When we
-# receive term signal the loop wil be killed. It has very low CPU usage.
-# When this process receives a signal to be stopped, shutd function will run.
+# Keep the script running until this process receives the TERM signal to be
+# stopped, which will trigger shutd and set the value to end the loop.
 while [ "${last_signal}" != "15" ]; do
     sleep 1
 done

--- a/test/alpine/.devcontainer.json
+++ b/test/alpine/.devcontainer.json
@@ -1,8 +1,8 @@
 {
 	"name": "dl-vscode-server-test",
-	"dockerComposeFile": "../compose.yml",
-	"service": "alpine-musl",
-	"workspaceFolder": "/home/app/src/github.com/b01/dl-vscode-server/test/alpine-musl",
+	"dockerComposeFile": "compose.yml",
+	"service": "alpine",
+	"workspaceFolder": "/home/app/src/github.com/b01/dl-vscode-server/test/alpine",
 	// Use this environment variable if you need to bind mount your local source code into a new container.
 	"remoteEnv": {
 		"LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}"
@@ -12,11 +12,10 @@
 	"customizations": {
 		"vscode": {
 			"settings": {
-				"terminal.integrated.shell.linux": "/bin/bash",
+				"terminal.integrated.shell.linux": "/bin/sh",
 			},
 			// Add the IDs of extensions you want installed when the container is created.
-			"extensions": [
-			]
+			"extensions": []
 		}
 	},
 	// Use 'postCreateCommand' to run commands after the container is created.

--- a/test/alpine/Dockerfile
+++ b/test/alpine/Dockerfile
@@ -52,7 +52,7 @@ RUN addgroup --system --gid ${USER_GID} ${USER_GROUP} \
 # && sed -i '|(root:x:0:0:root:/root:)/bin/ash$|$1|g' /etc/passwd
 USER ${USER_NAME}
 
-COPY --chown=${USER_NAME}:${USER_NAME} --chmod=+x download-vs-code.sh /tmp
+COPY --chown=${USER_NAME}:${USER_NAME} --chmod=777 download-vs-code.sh /tmp
 
 # Install VS Code Server
 RUN /tmp/download-vs-code.sh "linux" "x64" --dump-version

--- a/test/alpine/Dockerfile
+++ b/test/alpine/Dockerfile
@@ -55,7 +55,7 @@ USER ${USER_NAME}
 COPY --chown=${USER_NAME}:${USER_NAME} --chmod=777 download-vs-code.sh /tmp
 
 # Install VS Code Server
-RUN /tmp/download-vs-code.sh "linux" "x64" --dump-version
-RUN /tmp/download-vs-code.sh "linux" "x64" --dump-version --cli
+RUN /tmp/download-vs-code.sh "linux" "x64"
+RUN /tmp/download-vs-code.sh "linux" "x64" --cli
 
 WORKDIR ${WD}

--- a/test/alpine/Dockerfile
+++ b/test/alpine/Dockerfile
@@ -33,6 +33,13 @@ RUN apk --no-progress --purge --no-cache upgrade \
 && apk --no-progress --purge --no-cache upgrade \
  && rm -vrf /var/cache/apk/*
 
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD echo "healthy" || exit 1
+
+COPY --chmod=+x test/alpine/start.sh /usr/local/bin
+
+ENTRYPOINT [ "start.sh" ]
+
 # Add a non-root group and user to runas
 RUN addgroup --system --gid ${USER_GID} ${USER_GROUP} \
  && adduser --system \
@@ -41,19 +48,14 @@ RUN addgroup --system --gid ${USER_GID} ${USER_GROUP} \
     --uid ${USER_UID} \
     ${USER_NAME}
 
+#RUN cat /etc/passwd \
+# && sed -i '|(root:x:0:0:root:/root:)/bin/ash$|$1|g' /etc/passwd
 USER ${USER_NAME}
 
-COPY --chown=${USER_NAME}:${USER_NAME} test/alpine/start.sh /usr/local/bin
-
-HEALTHCHECK --interval=5m --timeout=3s \
-  CMD echo "healthy" || exit 1
-
-ENTRYPOINT [ "start.sh" ]
-
-COPY --chown=${USER_NAME}:${USER_NAME} --chmod=777 download-vs-code-server.sh /tmp
+COPY --chown=${USER_NAME}:${USER_NAME} --chmod=+x download-vs-code.sh /tmp
 
 # Install VS Code Server
-RUN chmod +x /tmp/download-vs-code-server.sh \
- && /tmp/download-vs-code-server.sh "linux" "x64" "yes"
+RUN /tmp/download-vs-code.sh "linux" "x64" --dump-version
+RUN /tmp/download-vs-code.sh "linux" "x64" --dump-version --cli
 
 WORKDIR ${WD}

--- a/test/alpine/Dockerfile
+++ b/test/alpine/Dockerfile
@@ -46,10 +46,9 @@ RUN addgroup --system --gid ${USER_GID} ${USER_GROUP} \
     --disabled-password \
     --ingroup ${USER_GROUP} \
     --uid ${USER_UID} \
+    --shell /bin/bash \
     ${USER_NAME}
 
-#RUN cat /etc/passwd \
-# && sed -i '|(root:x:0:0:root:/root:)/bin/ash$|$1|g' /etc/passwd
 USER ${USER_NAME}
 
 COPY --chown=${USER_NAME}:${USER_NAME} --chmod=777 download-vs-code.sh /tmp

--- a/test/alpine/README.md
+++ b/test/alpine/README.md
@@ -1,8 +1,12 @@
 # About
 
-This container is for testing out the pre-installed vscode server setup inside an Alpine contiainer.
+This container is for testing out the pre-installed vscode server setup inside
+an Alpine container.
 
-This image uses the Kohirens [Alpine GLIBC] image as a base, so you get a real version of GNU LibC built in an Alpine container for Alpine. So it should not have issues running node for VS Code server. Beside the warning about libc++ not having any version info.
+This image uses the Kohirens [Alpine GLIBC] image as a base, so you get a real
+version of GNU LibC built in an Alpine container for Alpine. So it should not
+have issues running node for VS Code server. Beside the warning about libc++
+not having any version info.
 
 ---
 

--- a/test/alpine/start.sh
+++ b/test/alpine/start.sh
@@ -23,9 +23,8 @@ echo "Started"
 
 last_signal=""
 
-# Fork a loop as a child process, which keeps this script running. When we
-# receive term signal the loop wil be killed. It has very low CPU usage.
-# When this process receives a signal to be stopped, shutd function will run.
+# Keep the script running until this process receives the TERM signal to be
+# stopped, which will trigger shutd and set the value to end the loop.
 while [ "${last_signal}" != "15" ]; do
     sleep 1
 done

--- a/test/debian/.devcontainer.json
+++ b/test/debian/.devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "dl-vscode-server-test",
-	"dockerComposeFile": "../compose.yml",
+	"dockerComposeFile": "compose.yml",
 	"service": "debian",
 	"workspaceFolder": "/home/app/src/github.com/b01/dl-vscode-server/test/debian",
 	// Use this environment variable if you need to bind mount your local source code into a new container.

--- a/test/debian/Dockerfile
+++ b/test/debian/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get -qq update -qq && apt-get -qq install -qq \
 && apt-get -qq update \
  && rm -rf /var/lib/apt/lists/*
 
-COPY --chmod=+x test/alpine/start.sh /usr/local/bin
+COPY --chmod=+x test/debian/start.sh /usr/local/bin
 
 HEALTHCHECK --interval=5m --timeout=3s \
   CMD echo "healthy" || exit 1

--- a/test/debian/Dockerfile
+++ b/test/debian/Dockerfile
@@ -45,7 +45,7 @@ RUN addgroup --gid ${USER_GID} ${USER_GROUP} \
 
 USER ${USER_NAME}
 
-COPY --chown=${USER_NAME}:${USER_NAME} --chmod=+x download-vs-code.sh /tmp
+COPY --chown=${USER_NAME}:${USER_NAME} --chmod=777 download-vs-code.sh /tmp
 
 # Install VS Code Server
 RUN /tmp/download-vs-code.sh "linux" "x64" --dump-version

--- a/test/debian/Dockerfile
+++ b/test/debian/Dockerfile
@@ -29,6 +29,13 @@ RUN apt-get -qq update -qq && apt-get -qq install -qq \
 && apt-get -qq update \
  && rm -rf /var/lib/apt/lists/*
 
+COPY --chmod=+x test/alpine/start.sh /usr/local/bin
+
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD echo "healthy" || exit 1
+
+ENTRYPOINT [ "start.sh" ]
+
 # Add a non-root group and user to runas
 RUN addgroup --gid ${USER_GID} ${USER_GROUP} \
  && adduser --disabled-password \
@@ -38,17 +45,11 @@ RUN addgroup --gid ${USER_GID} ${USER_GROUP} \
 
 USER ${USER_NAME}
 
-COPY --chown=${USER_NAME}:${USER_NAME} --chmod=644 test/alpine/start.sh /usr/local/bin
-
-HEALTHCHECK --interval=5m --timeout=3s \
-  CMD echo "healthy" || exit 1
-
-ENTRYPOINT [ "start.sh" ]
-
-COPY --chown=${USER_NAME}:${USER_NAME} --chmod=777 download-vs-code-server.sh /tmp
+COPY --chown=${USER_NAME}:${USER_NAME} --chmod=+x download-vs-code.sh /tmp
 
 # Install VS Code Server
-RUN chmod +x /tmp/download-vs-code-server.sh \
- && /tmp/download-vs-code-server.sh "linux" "x64" "yes"
+RUN /tmp/download-vs-code.sh "linux" "x64" --dump-version
+# Install VS Code CLI
+RUN /tmp/download-vs-code.sh "linux" "x64" --dump-version --cli
 
 WORKDIR ${WD}

--- a/test/debian/Dockerfile
+++ b/test/debian/Dockerfile
@@ -48,8 +48,8 @@ USER ${USER_NAME}
 COPY --chown=${USER_NAME}:${USER_NAME} --chmod=777 download-vs-code.sh /tmp
 
 # Install VS Code Server
-RUN /tmp/download-vs-code.sh "linux" "x64" --dump-version
+RUN /tmp/download-vs-code.sh "linux" "x64"
 # Install VS Code CLI
-RUN /tmp/download-vs-code.sh "linux" "x64" --dump-version --cli
+RUN /tmp/download-vs-code.sh "linux" "x64" --cli
 
 WORKDIR ${WD}

--- a/test/debian/README.md
+++ b/test/debian/README.md
@@ -1,12 +1,4 @@
 # DL VS Code Server
 
 This container is for testing out the pre-installed vscode server setup inside
-an Alpine container.
-
-This script downloads a tar of VS Code Server, then extracts it to a location
-expected by VS Code clients. The intention of this script is to pre-install
-the server during image build. This helps ensure, in certain scenarios,
-that the server is there when internet is not; while still allowing your VS
-Code client to connect to it.
-
-Another reason is to prevent the constand download and install of VS Code server when the container is removed then run again later. With the sever being embeded in the image, it should not need to download until an update to VS Code itself, which would expect a new version of the server.
+a Debian container. Which is fully supported by VS Code Server.

--- a/test/debian/README.md
+++ b/test/debian/README.md
@@ -1,5 +1,12 @@
 # DL VS Code Server
 
-This script downloads a tar of VS Code Server, then extracts it to a location expected by VS Code clients. The intention of this script is to download and setup the server during image build. This helps to ensure in certain scenarios that the server is there when internet is not, while still allowing your VS code client to connect to it.
+This container is for testing out the pre-installed vscode server setup inside
+an Alpine container.
+
+This script downloads a tar of VS Code Server, then extracts it to a location
+expected by VS Code clients. The intention of this script is to pre-install
+the server during image build. This helps ensure, in certain scenarios,
+that the server is there when internet is not; while still allowing your VS
+Code client to connect to it.
 
 Another reason is to prevent the constand download and install of VS Code server when the container is removed then run again later. With the sever being embeded in the image, it should not need to download until an update to VS Code itself, which would expect a new version of the server.


### PR DESCRIPTION
## Added

* Script download-vs-code.sh - To replace download-vs-code-server.sh without introduction breaking changes. This new script combines the features of downloading VS Code Server and VS Code CLI.

## Miscellaneous

* Updated Documentation all around.
* Upgrade CI Tools.
* Moved Dev Container Configurations for Tests.