### PR TITLE
Fixed Link in READE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ curl -L https://raw.githubusercontent.com/b01/dl-vscode-server/main/download-vs-
 ### Docker
 
 ```dockerfile
-ADD --chmod=777 \
-    https://raw.githubusercontent.com/b01/dl-vscode-server/updates-2024-05-16-01/download-vs-code.sh \
+DL_VER="0.2.1"
+ADD --chmod=755 \
+    https://raw.githubusercontent.com/b01/dl-vscode-server/refs/tags/${DL_VER}/download-vs-code.sh \
     .
 
 # Install VS Code Server and Requirements

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ Print this usage info
     specify which extensions to install. expects a string of full extension names seperated by commas,
     e.g ms-vscode.PowerShell,redhat.ansible,ms-python.vscode-pylance
 
-
+`--use-commit`
+    Download VS Code Server/CLI with the provided commit sha. This allows to download the matching VS Code Server for an existing VS Code installation that is not the newest commit version.
 ---
 
 [b01/download-vs-code-server.sh]: https://gist.github.com/b01/0a16b6645ab7921b0910603dfb85e4fb

--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ curl -L https://raw.githubusercontent.com/b01/dl-vscode-server/main/download-vs-
 
 ```dockerfile
 DL_VER="0.2.1"
-ADD --chmod=755 \
-    https://raw.githubusercontent.com/b01/dl-vscode-server/refs/tags/${DL_VER}/download-vs-code.sh \
-    .
+# Install VS Code Server
+RUN curl -LO https://raw.githubusercontent.com/b01/dl-vscode-server/refs/tags/${DL_VER}/download-vs-code.sh \
+ && chmod +x download-vs-code.sh \
+ && ./download-vs-code.sh "linux" "x64" --extensions "ms-vscode.cpptools"
 
 # Install VS Code Server and Requirements
 RUN ./download-vs-code.sh "linux" "x64" --alpine --extensions dbaeumer.vscode-eslint

--- a/README.md
+++ b/README.md
@@ -39,10 +39,7 @@ DL_VER="0.2.1"
 # Install VS Code Server
 RUN curl -LO https://raw.githubusercontent.com/b01/dl-vscode-server/refs/tags/${DL_VER}/download-vs-code.sh \
  && chmod +x download-vs-code.sh \
- && ./download-vs-code.sh "linux" "x64" --extensions "ms-vscode.cpptools"
-
-# Install VS Code Server and Requirements
-RUN ./download-vs-code.sh "linux" "x64" --alpine --extensions dbaeumer.vscode-eslint
+ && ./download-vs-code.sh "linux" "x64" --extensions dbaeumer.vscode-eslint
 ```
 
 ## How To Use
@@ -51,7 +48,7 @@ RUN ./download-vs-code.sh "linux" "x64" --alpine --extensions dbaeumer.vscode-es
 
 ### Example:
 
-download-vs-code.sh \"linux\" \"x64\" --alpine
+download-vs-code.sh \"linux\" \"x64\" --extensions dbaeumer.vscode-eslint --use-commit 384ff7382de624fb94dbaf6da11977bba1ecd427
 
 ### Options
 

--- a/download-vs-code.sh
+++ b/download-vs-code.sh
@@ -54,7 +54,7 @@ Options
     e.g \"ms-vscode.PowerShell redhat.ansible ms-python.vscode-pylance\"
 
 --use-commit
-    Download VS ode Server with the provided commit sha. This allows to download the matching VS Code Server for
+    Download VS Code Server/CLI with the provided commit sha. This allows to download the matching VS Code Server for
     an existing VS Code installation that is not the newest commit version.
 
 -h, --help

--- a/download-vs-code.sh
+++ b/download-vs-code.sh
@@ -242,10 +242,11 @@ if [ -n "${USE_COMMIT}" ]; then
 else
     # We hard-code this because all but a few options returns a 404.
     commit_sha=$(get_latest_release "win32" "x64" "${BUILD}")
-    if [ -z "${commit_sha}" ]; then
-        echo "could not get the VS Code latest commit sha, exiting"
-        exit 1
-    fi
+fi
+
+if [ -z "${commit_sha}" ]; then
+    echo "could not get the VS Code latest commit sha, exiting"
+    exit 1
 fi
 
 if [ "${DUMP_COMMIT_SHA}" = "yes" ]; then


### PR DESCRIPTION
The link was to an old branch that was deleted when merged. So it would send users to a 404. The new link show how to pull from GitHub and set the version you want.